### PR TITLE
Select callback

### DIFF
--- a/js/jquery.stepy.js
+++ b/js/jquery.stepy.js
@@ -183,7 +183,7 @@
 				var isBlocked = (maxStep <= clicked);
 
 				if (clicked != current) {
-					selectStep($this, maxStep, isBlocked);
+					selectStep($this, maxStep, isBlocked, opt);
 
 			        if (opt.finishButton && maxStep + 1 == size) {
 	                	finish.show();
@@ -232,7 +232,7 @@
         		html:		opt.backLabel
         	}).click(function() {
         		if (!opt.back || !isStopCallback(opt.back, index - 1)) {
-	                selectStep($this, index - 1, false);
+	                selectStep($this, index - 1, false, opt);
 
 	                if (index + 1 == size) {
 	                	finish.hide();
@@ -253,7 +253,7 @@
 	        		var maxStep		= getMaxStep($this, opt, index + 1),
 	        			isBlocked	= (maxStep <= index);
 
-					selectStep($this, maxStep, isBlocked);
+					selectStep($this, maxStep, isBlocked, opt);
 	
 			        if (opt.finishButton && maxStep + 1 == size) {
 	                	finish.show();
@@ -284,7 +284,7 @@
 		return $this;
 	};
 
-	function selectStep(context, index, isBlocked) {
+	function selectStep(context, index, isBlocked, opt) {
 		var id		= context.attr('id'),
 			$steps	= context.children('fieldset'),
 			size	= $steps.size(),
@@ -305,6 +305,10 @@
         		firstField.focus();
         	}
         }
+		if (opt.select) {
+			opt.select.call(this, index +1);
+			console.log("Displaying step " + (index +1).toString());
+		}
 	};
 
 	function validate(context, index, opt) {
@@ -330,7 +334,7 @@
 				}
 			} else {
 				if (opt.block) {
-					selectStep(context, index, true);
+					selectStep(context, index, true, opt);
 				}
 
 				if (opt.errorImage) {
@@ -351,7 +355,7 @@
 			return;
 		}
 
-		selectStep(context, index - 1, false);
+		selectStep(context, index - 1, false, {});
 
 		$.fn.stepy;
 	};
@@ -407,7 +411,8 @@
 		nextLabel:		'Next &gt;',
 		titleClick:		false,
 		titleTarget:	'',
-		validate:		false
+		validate:		false,
+		select: 		null
 	};
 
 })(jQuery);


### PR DESCRIPTION
Added a callback called select that fires when a wizard step is selected and displayed.

next and back only fire before validation so you'll get multiple calls to next() if there are validation errors with block:true ..

Not sure if this is the best way to fix this, but it's an attempt.. 

Background:
jQuery FullCalendar can't be initialized while the surrounding form is not show (for whatever reason) so I had to pack the .fullcalendar() call inside my next callback on a certain index. 
In case of a validation error happening next was called but the step was not displayed .. putting the initialization back into limbo mode :)

greetings Daniel
