### PR TITLE
Removed inline JavaScript for CSP

### DIFF
--- a/lib/jquery.stepy.js
+++ b/lib/jquery.stepy.js
@@ -168,9 +168,10 @@
     }, _createBackButton: function(nav, index) {
       var self       = this,
           that       = $(this),
-          attributes = { href: 'javascript:void(0);', 'class': 'button-back', html: self.opt.backLabel };
+          attributes = { href: '#', 'class': 'button-back', html: self.opt.backLabel };
 
-      $('<a />', attributes).on('click.stepy', function() {
+      $('<a />', attributes).on('click.stepy', function(e) {
+        e.preventDefault();
         if (!self.opt.back || methods._execute.call(self, self.opt.back, index - 1)) {
           methods.step.call(self, (index - 1) + 1);
         }
@@ -205,9 +206,10 @@
     }, _createNextButton: function(nav, index) {
       var self       = this,
           that       = $(this),
-          attributes = { href: 'javascript:void(0);', 'class': 'button-next', html: self.opt.nextLabel };
+          attributes = { href: '#', 'class': 'button-next', html: self.opt.nextLabel };
 
-      $('<a/>', attributes).on('click.stepy', function() {
+      $('<a/>', attributes).on('click.stepy', function(e) {
+        e.preventDefault();
         if (!self.opt.next || methods._execute.call(that, self.opt.next, index + 1)) {
           methods.step.call(self, (index + 1) + 1);
         }


### PR DESCRIPTION
If you enable Content Security Policy (CSP) it will bork about javascript:void() as this is inline JavaScript.

Replaced it with # and using e.preventDefault() so it behaves the same but won't show an error.
