### PR TITLE
fix external method caller

### DIFF
--- a/lib/jquery.stepy.js
+++ b/lib/jquery.stepy.js
@@ -383,9 +383,13 @@
   $.fn.stepy = function(method) {
     if (methods[method]) {
       var args = Array.prototype.slice.call(arguments, 1);
-      return this.each(function() {
+      var ret = [];
+
+      this.each(function() {
         return methods[method].apply(this, args);
       });
+
+      return ret;
     } else if (typeof method === 'object' || !method) {
       return methods.init.apply(this, arguments);
     } else {


### PR DESCRIPTION
Allow `$('.form').stepy('step', 1)` which raises error due to jQuery array object
