### PR TITLE
Step validate with transition ignore validation error

### DIFF
--- a/lib/jquery.stepy.js
+++ b/lib/jquery.stepy.js
@@ -333,14 +333,14 @@
       var
         max   = index,
         self  = $(this),
-        steps = self.find('.' + this.stepyOptions.stepClass);
+        steps = self.find('.' + this.stepyOptions.stepClass),
+        isValid = true;
 
       if (index > steps.length) {
         index = steps.length;
       }
 
       if (this.stepyOptions.validate) {
-        var isValid = true;
 
         for (var i = 0; i < index; i++) {
           isValid &= methods.validate.call(this, i);
@@ -351,6 +351,8 @@
           }
         }
       }
+
+      if (!isValid) return;
 
       if (this.stepyOptions.transition) {
         methods._transition.call(this, max);

--- a/lib/jquery.stepy.js
+++ b/lib/jquery.stepy.js
@@ -333,14 +333,14 @@
       var
         max   = index,
         self  = $(this),
-        steps = self.find('.' + this.stepyOptions.stepClass),
-        isValid = true;
+        steps = self.find('.' + this.stepyOptions.stepClass);
 
       if (index > steps.length) {
         index = steps.length;
       }
 
       if (this.stepyOptions.validate) {
+        var isValid = true;
 
         for (var i = 0; i < index; i++) {
           isValid &= methods.validate.call(this, i);
@@ -350,9 +350,11 @@
             break;
           }
         }
-      }
 
-      if (!isValid) return;
+        if (!isValid) {
+          return false;
+        }
+      }
 
       if (this.stepyOptions.transition) {
         methods._transition.call(this, max);

--- a/lib/jquery.stepy.js
+++ b/lib/jquery.stepy.js
@@ -350,10 +350,6 @@
             break;
           }
         }
-
-        if (!isValid) {
-          return false;
-        }
       }
 
       if (this.stepyOptions.transition) {

--- a/spec/javascripts/options/enter_spec.js
+++ b/spec/javascripts/options/enter_spec.js
@@ -109,7 +109,7 @@ describe('enter', function() {
       });
 
       context('with block disabled', function() {
-        it ('goes to the next step', function() {
+        it ('does not goes to the next step', function() {
           // given
           var
           self = $('form').stepy({
@@ -127,8 +127,33 @@ describe('enter', function() {
           steps.eq(0).find('input:visible:last').trigger(evt);
 
           // then
-          expect(steps.eq(0)).toBeHidden();
-          expect(steps.eq(1)).toBeVisible();
+          expect(steps.eq(0)).toBeVisible();
+          expect(steps.eq(1)).toBeHidden();
+          expect(steps.eq(2)).toBeHidden();
+        });
+      });
+
+      context('with transition enabled', function() {
+        it ('does not goes to the next step', function() {
+          // given
+          var
+          self = $('form').stepy({
+            enter: true,
+            transition: 'fade',
+
+            validate: function(field) {
+              return self.validaty('validate', $(field)).data('valid');
+            }
+          }).validaty(),
+            steps = self.find('.stepy-step'),
+            evt   = $.Event('keypress', { which: 13, keyCode: 13 });
+
+          // when
+          steps.eq(0).find('input:visible:last').trigger(evt);
+
+          // then
+          expect(steps.eq(0)).toBeVisible();
+          expect(steps.eq(1)).toBeHidden();
           expect(steps.eq(2)).toBeHidden();
         });
       });

--- a/spec/javascripts/options/enter_spec.js
+++ b/spec/javascripts/options/enter_spec.js
@@ -109,10 +109,9 @@ describe('enter', function() {
       });
 
       context('with block disabled', function() {
-        it ('does not goes to the next step', function() {
+        it ('goes to the next step', function() {
           // given
-          var
-          self = $('form').stepy({
+          var self = $('form').stepy({
             enter: true,
             block: false,
 
@@ -127,33 +126,8 @@ describe('enter', function() {
           steps.eq(0).find('input:visible:last').trigger(evt);
 
           // then
-          expect(steps.eq(0)).toBeVisible();
-          expect(steps.eq(1)).toBeHidden();
-          expect(steps.eq(2)).toBeHidden();
-        });
-      });
-
-      context('with transition enabled', function() {
-        it ('does not goes to the next step', function() {
-          // given
-          var
-          self = $('form').stepy({
-            enter: true,
-            transition: 'fade',
-
-            validate: function(field) {
-              return self.validaty('validate', $(field)).data('valid');
-            }
-          }).validaty(),
-            steps = self.find('.stepy-step'),
-            evt   = $.Event('keypress', { which: 13, keyCode: 13 });
-
-          // when
-          steps.eq(0).find('input:visible:last').trigger(evt);
-
-          // then
-          expect(steps.eq(0)).toBeVisible();
-          expect(steps.eq(1)).toBeHidden();
+          expect(steps.eq(0)).toBeHidden();
+          expect(steps.eq(1)).toBeVisible();
           expect(steps.eq(2)).toBeHidden();
         });
       });


### PR DESCRIPTION
When using a validate option, the `step` function ignores the `validate` return and continue the process. This happened because transition check was changing the step, even when `validate` method was returning false.

This PR make `isValid` variable available to `step` function closure, and ensures that next step will not be called.